### PR TITLE
chore: target .net 9

### DIFF
--- a/Default.props
+++ b/Default.props
@@ -1,0 +1,19 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GameRefsPath>$(MSBuildThisFileDirectory)Resonite</GameRefsPath>
+    <GameRefsPath Condition="Exists('C:\Program Files (x86)\Steam\steamapps\common\Resonite\')">C:\Program Files (x86)\Steam\steamapps\common\Resonite\</GameRefsPath>
+    <GameRefsPath Condition="Exists('D:\Program Files (x86)\Steam\steamapps\common\Resonite\')">D:\Program Files (x86)\Steam\steamapps\common\Resonite\</GameRefsPath>
+    <GameRefsPath Condition="Exists('E:\Program Files (x86)\Steam\steamapps\common\Resonite\')">E:\Program Files (x86)\Steam\steamapps\common\Resonite\</GameRefsPath>
+    <GameRefsPath Condition="Exists('C:\SteamLibrary\steamapps\common\Resonite\')">C:\SteamLibrary\steamapps\common\Resonite\</GameRefsPath>
+    <GameRefsPath Condition="Exists('D:\SteamLibrary\steamapps\common\Resonite\')">D:\SteamLibrary\steamapps\common\Resonite\</GameRefsPath>
+    <GameRefsPath Condition="Exists('E:\SteamLibrary\steamapps\common\Resonite\')">E:\SteamLibrary\steamapps\common\Resonite\</GameRefsPath>
+    <GameRefsPath Condition="Exists('C:\Programs\Steam\steamapps\common\Resonite\')">C:\Programs\Steam\steamapps\common\Resonite\</GameRefsPath>
+    <GameRefsPath Condition="Exists('D:\Programs\Steam\steamapps\common\Resonite\')">D:\Programs\Steam\steamapps\common\Resonite\</GameRefsPath>
+    <GameRefsPath Condition="Exists('E:\Programs\Steam\steamapps\common\Resonite\')">E:\Programs\Steam\steamapps\common\Resonite\</GameRefsPath>
+    <GameRefsPath Condition="Exists('$(HOME)/.steam/steam/steamapps/common/Resonite/')">$(HOME)/.steam/steam/steamapps/common/Resonite/</GameRefsPath>
+  </PropertyGroup>
+</Project>

--- a/SessionTweaks.csproj
+++ b/SessionTweaks.csproj
@@ -1,4 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="./Default.props"/>
+
+  <PropertyGroup>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="SkyFrost.Base">
       <HintPath>$(GameRefsPath)SkyFrost.Base.dll</HintPath>
@@ -8,6 +14,12 @@
     </Reference>
     <Reference Include="FrooxEngine">
       <HintPath>$(GameRefsPath)FrooxEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="0Harmony">
+      <HintPath>$([System.IO.File]::Exists('$(GameRefsPath)MonkeyLoader\0Harmony.dll') ? '$(GameRefsPath)MonkeyLoader\0Harmony.dll' : '$(GameRefsPath)rml_libs\0Harmony.dll')</HintPath>
+    </Reference>
+    <Reference Include="ResoniteModLoader">
+      <HintPath>$(GameRefsPath)\Libraries\ResoniteModLoader.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Since the graphical client went to .NET 9, this PR changes the target framework to .NET 9. Otherwise, the mod will not work as demonstrated by this log message:

```
❌4:53:41 PM.254 (FPS: 53):	Exception when running synchronous action (Stage: UpdatingStreams):
System.MissingMethodException: Method not found: 'FrooxEngine.Slot FrooxEngine.Slot.Duplicate(FrooxEngine.Slot, Boolean, FrooxEngine.DuplicationSettings)'.
   at CorJitResult MonoMod.Core.Interop.CoreCLR+V60.InvokeCompileMethod(IntPtr functionPtr, IntPtr thisPtr, IntPtr corJitInfo, CORINFO_METHOD_INFO* methodInfo, uint flags, Byte** nativeEntry, UInt32* nativeSizeOfCode)
   at CorJitResult MonoMod.Core.Platforms.Runtimes.Core60Runtime+JitHookDelegateHolder.CompileMethodHook(IntPtr jit, IntPtr corJitInfo, CORINFO_METHOD_INFO* methodInfo, uint flags, Byte** nativeEntry, UInt32* nativeSizeOfCode)
   at void SessionTweaks.SessionTweaks+SessionTweaks_SessionItemPatch.Postfix(SessionItem __instance)
   at void FrooxEngine.SessionItem.Update_Patch1(SessionItem this, SessionInfo session, bool isCurrent)
   at void FrooxEngine.ContactsDialog.UpdateSessionItems(ContactData status)
   at void FrooxEngine.ContactsDialog.UpdateContactItem(ContactData data)
   at void FrooxEngine.World.RunSynchronousActions()
```